### PR TITLE
fix: bad cross-link in docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -182,7 +182,7 @@ All transformations are differentiable and JAX-compatible.
 
 ### Using Bounds in Practice
 
-See also :doc:`parameters_overview` for a catalogue of available transforms
+See also :doc:`parameter_transforms` for a catalogue of available transforms
 and guidance on applying them directly to flat states.
 
 ```python


### PR DESCRIPTION
This is a tiny fix in docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an internal documentation reference to point to the correct guide for parameter transformation topics, improving navigation and accuracy in the introduction section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->