### PR TITLE
perf: avoid JIT retrace in fit() for repeated calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
         args: [--config-file=pyproject.toml]
         additional_dependencies:
           - pytest
+          - jax
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.11.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,4 +181,4 @@ isort.required-imports = ["from __future__ import annotations"]
 [tool.uv.sources]
 pyhs3 = { git = "https://github.com/MoAly98/pyhs3", branch = "fix/funcs_ref_funcs" }
 pyhf = { git = "https://github.com/scikit-hep/pyhf", branch = "main" }
-paramore = { git = "https://github.com/maxgalli/paramore", branch = "master" }
+paramore = { git = "https://github.com/maxgalli/paramore", branch = "feat/bernstein-analytical-integrate" }

--- a/src/everwillow/_src/inference/fitting.py
+++ b/src/everwillow/_src/inference/fitting.py
@@ -43,6 +43,17 @@ def _reconstruct_full_state(
     return ewp.wrap(full_state_transformed, bounds.mapping)
 
 
+class _WrappedNLL(eqx.Module):
+    """NLL evaluated on the free parameters, with observation as dynamic input."""
+
+    nll_fn: tp.Callable = eqx.field(static=True)
+    observation: PyTree
+
+    def __call__(self, new_state, fn_args):
+        full_state = _reconstruct_full_state(new_state, args=fn_args)
+        return self.nll_fn(full_state.to_pytree(), self.observation)
+
+
 class FitResult(eqx.Module, tp.Generic[V]):
     """Result of a fit operation."""
 
@@ -334,13 +345,14 @@ def _fit(
         predicate=predicate,
     )
 
+    # Convert to JAX arrays so eqx.filter_jit treats them as dynamic inputs.
+    fixed_state = jax.tree.map(jnp.asarray, fixed_state)
+
     # Prepare args for reconstructing full state
     args: Args = (fixed_state, bounds)
 
     # Wrap nll to only take free parameters
-    def wrapped_nll(new_state, fn_args):
-        full_state = _reconstruct_full_state(new_state, args=fn_args)
-        return nll_fn(full_state.to_pytree(), observation)
+    wrapped_nll = _WrappedNLL(nll_fn=nll_fn, observation=observation)
 
     # Set up solver
     if solver is None:

--- a/src/everwillow/_src/inference/fitting.py
+++ b/src/everwillow/_src/inference/fitting.py
@@ -28,6 +28,40 @@ if tp.TYPE_CHECKING:
     from everwillow._src.inference.callback import Callback
 
 
+def _ensure_array_leaves(state: sl.State, name: str) -> sl.State:
+    """Enforce the fit input contract on a state's leaves.
+
+    Leaves must be ``jax.Array`` or ``float``; floats are converted with
+    ``jnp.asarray`` so that downstream JIT boundaries treat them as dynamic
+    inputs rather than static constants (avoiding retraces when values change
+    between calls). Ellipsis sentinels used by ``fixed`` pass through unchanged.
+
+    Args:
+        state: State whose leaves are checked.
+        name: Argument name used in error messages.
+
+    Returns:
+        State with all numeric leaves as JAX arrays.
+
+    Raises:
+        TypeError: If a leaf is neither a ``jax.Array``, a ``float``, nor Ellipsis.
+    """
+
+    def ensure(path, value):
+        if value is Ellipsis:
+            return value
+        if isinstance(value, (float, jax.Array)):
+            return jnp.asarray(value)
+        # path[0] is the State's internal GetAttrKey("_mapping"); the rest is the leaf key
+        msg = (
+            f"{name}{jax.tree_util.keystr(path[1:])} has type {type(value).__name__}; "
+            "leaves must be jax.Array or float (convert with jnp.asarray)"
+        )
+        raise TypeError(msg)
+
+    return jax.tree_util.tree_map_with_path(ensure, state)
+
+
 def _reconstruct_full_state(
     free_state: sl.State[V],
     *,
@@ -329,6 +363,12 @@ def _fit(
         msg = "bounds must be a State or None"  # type: ignore[unreachable]
         raise TypeError(msg)
 
+    # Enforce the input contract at the public boundary: leaves must be
+    # jax.Arrays or floats, converted once here so every downstream JIT
+    # boundary sees dynamic array inputs (no retrace when values change).
+    params = _ensure_array_leaves(params, "params")
+    fixed = _ensure_array_leaves(fixed, "fixed")
+
     # Set fixed values
     updated_params = sl.update(params, updates=fixed)
 
@@ -344,9 +384,6 @@ def _fit(
         param_state_transformed,
         predicate=predicate,
     )
-
-    # Convert to JAX arrays so eqx.filter_jit treats them as dynamic inputs.
-    fixed_state = jax.tree.map(jnp.asarray, fixed_state)
 
     # Prepare args for reconstructing full state
     args: Args = (fixed_state, bounds)
@@ -418,11 +455,16 @@ def fit(
         nll_fn: Callable returning the scalar NLL. It must accept the parameter
             pytree as its first argument and observation data as its second.
         params: Initial parameter values organised as a state (e.g. mapping or
-            nested containers).
+            nested containers). Leaves must be ``jax.Array`` or ``float``;
+            floats are converted to JAX arrays at the call boundary.
         observation: Observed data passed to ``nll_fn``. Can be any pytree structure
-            (dict, array, nested containers, etc.).
+            (dict, array, nested containers, etc.). Array leaves are treated as
+            dynamic JIT inputs; non-array leaves are static, and changing them
+            between calls triggers recompilation.
         fixed: Optional state of canonicalized keys to fixed values for
             identifying parameters that should remain unchanged during the fit.
+            Values must be ``jax.Array``, ``float``, or ``...`` to fix a
+            parameter at its current value in *params*.
         bounds: Optional state of :class:`~everwillow._src.parameters.transforms.TransformBase`
             instances. When provided, parameters are unwrapped via the transform's
             ``unwrap`` method prior to optimisation and wrapped back afterwards.
@@ -506,11 +548,17 @@ def ifit(
     Args:
         nll_fn: Callable returning the scalar NLL. It must accept the parameter
             pytree as its first argument and observation data as its second.
-        params: Initial parameter values organised as a state.
+        params: Initial parameter values organised as a state. Leaves must be
+            ``jax.Array`` or ``float``; floats are converted to JAX arrays at
+            the call boundary.
         observation: Observed data passed to ``nll_fn``. Can be any pytree structure
-            (dict, array, nested containers, etc.).
+            (dict, array, nested containers, etc.). Array leaves are treated as
+            dynamic JIT inputs; non-array leaves are static, and changing them
+            between calls triggers recompilation.
         fixed: Optional state of canonicalized keys to fixed values for
             identifying parameters that should remain unchanged during the fit.
+            Values must be ``jax.Array``, ``float``, or ``...`` to fix a
+            parameter at its current value in *params*.
         bounds: Optional state of :class:`~everwillow._src.parameters.transforms.TransformBase`
             instances for parameter bounds.
         solver: :class:`optimistix.AbstractMinimiser` instance to use. Defaults to

--- a/src/everwillow/_src/inference/fitting.py
+++ b/src/everwillow/_src/inference/fitting.py
@@ -44,7 +44,7 @@ def _reconstruct_full_state(
 
 
 class _WrappedNLL(eqx.Module):
-    """NLL evaluated on the free parameters, with observation as dynamic input."""
+    """NLL evaluated on the free parameters, holding a fixed observation."""
 
     nll_fn: tp.Callable = eqx.field(static=True)
     observation: PyTree

--- a/src/everwillow/_src/inference/hypotest/distributions.py
+++ b/src/everwillow/_src/inference/hypotest/distributions.py
@@ -86,19 +86,19 @@ def _build_expected_bands(
     )
 
 
-def _require_q_asimov(result: TestStatResult, cls_name: str, pval_type: str) -> bool:
-    """Check that q_asimov is available, warn if not.
+def _require_q_asimov(result: TestStatResult, cls_name: str, pval_type: str) -> Array | None:
+    """Return the Asimov test statistic, warning if it is missing.
 
     Returns:
-        True if q_asimov is present, False otherwise.
+        ``result.q_asimov`` if present, None otherwise.
     """
     if result.q_asimov is None:
         warnings.warn(
             f"{pval_type} p-value computation in {cls_name} cannot be performed without an Asimov test statistic.",
             stacklevel=3,
         )
-        return False
-    return True
+        return None
+    return result.q_asimov
 
 
 # =============================================================================
@@ -215,10 +215,11 @@ class TMuAsymptotic(Distribution):
         :math:`q_A = \mu^2/\sigma^2` (Asimov under :math:`\mu'=0`),
         so :math:`\sqrt{q_A} = \mu/\sigma = (\mu-\mu')/\sigma`.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Alternative"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Alternative")
+        if q_asimov is None:
             return None
         sqrt_q = jnp.sqrt(jnp.maximum(result.value, 0.0))
-        sqrt_qa = jnp.sqrt(jnp.maximum(result.q_asimov, 0.0))
+        sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
         return 2.0 - _PHI(sqrt_q + sqrt_qa) - _PHI(sqrt_q - sqrt_qa)
 
 
@@ -258,10 +259,10 @@ class TMuTildeAsymptotic(Distribution):
                     & \text{if } \tilde{t} > q_A
             \end{cases}
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Null"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Null")
+        if q_asimov is None:
             return None
         q = result.value
-        q_asimov = result.q_asimov
         sqrt_q = jnp.sqrt(jnp.maximum(q, 0.0))
         sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
 
@@ -284,10 +285,10 @@ class TMuTildeAsymptotic(Distribution):
                     & \text{if } \tilde{t} > q_A
             \end{cases}
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Alternative"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Alternative")
+        if q_asimov is None:
             return None
         q = result.value
-        q_asimov = result.q_asimov
         sqrt_q = jnp.sqrt(jnp.maximum(q, 0.0))
         sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
 
@@ -319,10 +320,11 @@ class Q0Asymptotic(Distribution):
         :math:`q_A = \mu_\text{asimov}^2/\sigma^2` (Asimov under signal),
         so :math:`\sqrt{q_A} = \mu_\text{asimov}/\sigma`.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Alternative"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Alternative")
+        if q_asimov is None:
             return None
         sqrt_q = jnp.sqrt(jnp.maximum(result.value, 0.0))
-        sqrt_qa = jnp.sqrt(jnp.maximum(result.q_asimov, 0.0))
+        sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
         return 1.0 - _PHI(sqrt_q - sqrt_qa)
 
     def expected_pvalues(self, result: TestStatResult) -> ExpectedBands | None:
@@ -340,10 +342,11 @@ class Q0Asymptotic(Distribution):
             ExpectedBands with (pnull, palt) at each sigma level,
             or None if q_asimov is missing.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Expected"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Expected")
+        if q_asimov is None:
             return None
 
-        sqrt_qa = jnp.sqrt(jnp.maximum(result.q_asimov, 0.0))
+        sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
 
         def expected_q_fn(n: float) -> Array:
             return jnp.maximum(sqrt_qa + n, 0.0) ** 2
@@ -374,10 +377,11 @@ class QMuAsymptotic(Distribution):
         :math:`q_A = \mu^2/\sigma^2` (Asimov under :math:`\mu'=0`),
         so :math:`\sqrt{q_A} = \mu/\sigma`.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Alternative"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Alternative")
+        if q_asimov is None:
             return None
         sqrt_q = jnp.sqrt(jnp.maximum(result.value, 0.0))
-        sqrt_qa = jnp.sqrt(jnp.maximum(result.q_asimov, 0.0))
+        sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
         return 1.0 - _PHI(sqrt_q - sqrt_qa)
 
     def expected_pvalues(self, result: TestStatResult) -> ExpectedBands | None:
@@ -397,10 +401,11 @@ class QMuAsymptotic(Distribution):
             ExpectedBands with (pnull, palt) at each sigma level,
             or None if q_asimov is missing.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Expected"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Expected")
+        if q_asimov is None:
             return None
 
-        sigma = sigma_from_asimov(result.test, result.q_asimov)
+        sigma = sigma_from_asimov(result.test, q_asimov)
         # Guard: at poi=0, sigma=0 → mu/sigma = 0/0 = NaN.
         # Use 0 instead: all expected q become 0, giving CLs=1.0.
         mu_over_sigma = jnp.where(sigma > 0, result.test / sigma, 0.0)
@@ -445,10 +450,10 @@ class QTildeAsymptotic(Distribution):
                     & \text{if } \tilde{q} > q_A
             \end{cases}
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Null"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Null")
+        if q_asimov is None:
             return None
         q = result.value
-        q_asimov = result.q_asimov
         sqrt_q = jnp.sqrt(jnp.maximum(q, 0.0))
         sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
 
@@ -469,10 +474,10 @@ class QTildeAsymptotic(Distribution):
                     & \text{if } \tilde{q} > q_A
             \end{cases}
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Alternative"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Alternative")
+        if q_asimov is None:
             return None
         q = result.value
-        q_asimov = result.q_asimov
         sqrt_q = jnp.sqrt(jnp.maximum(q, 0.0))
         sqrt_qa = jnp.sqrt(jnp.maximum(q_asimov, 0.0))
 
@@ -503,10 +508,11 @@ class QTildeAsymptotic(Distribution):
             ExpectedBands with (pnull, palt) at each sigma level,
             or None if q_asimov is missing.
         """
-        if not _require_q_asimov(result, self.__class__.__name__, "Expected"):
+        q_asimov = _require_q_asimov(result, self.__class__.__name__, "Expected")
+        if q_asimov is None:
             return None
 
-        sigma = sigma_from_asimov(result.test, result.q_asimov)
+        sigma = sigma_from_asimov(result.test, q_asimov)
         # Guard: at poi=0, sigma=0 → mu/sigma = 0/0 = NaN.
         # Use 0 instead: all expected q become 0, giving CLs=1.0.
         mu_over_sigma = jnp.where(sigma > 0, result.test / sigma, 0.0)

--- a/src/everwillow/_src/statelib/state.py
+++ b/src/everwillow/_src/statelib/state.py
@@ -378,7 +378,7 @@ def split(state: State[V]) -> tuple[State[V], ...]:
     child_treedefs = jtu.treedef_children(state.treedefmeta.treedef)
     offset, states = 0, []
     for child_td in child_treedefs:
-        n = child_td.num_leaves
+        n = child_td.num_leaves  # type: ignore[attr-defined]
         child_keys = state.treedefmeta.keys[offset : offset + n]
         child_map = {k: state[k] for k in child_keys}
         states.append(State(child_map, treedefmeta=TreeDefMeta(child_td, child_keys)))

--- a/tests/inference/test_fitting.py
+++ b/tests/inference/test_fitting.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import optimistix as optx
 import pytest
 from jaxtyping import PyTree
@@ -755,6 +756,118 @@ class TestFitInternal:
 
         with pytest.raises(TypeError, match="params must be a State"):
             ew.ifit(nll, {"x": 0.0}, {}, progress=False)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "leaf",
+        [
+            pytest.param(2.5, id="python-float"),
+            pytest.param(np.float64(2.5), id="numpy-scalar"),
+            pytest.param(jnp.asarray(2.5), id="jax-array"),
+        ],
+    )
+    def test_params_scalar_and_array_leaves_accepted(self, leaf):
+        """params leaves may be jax.Arrays or Python/NumPy scalars."""
+
+        def nll(params, observation):
+            return (params["x"] - 2.0) ** 2
+
+        result = ew.fit(nll, sl.State.from_pytree({"x": leaf}), {})
+
+        assert jnp.isclose(result.params["x"], 2.0, atol=1e-2)
+
+    @pytest.mark.parametrize(
+        "leaf",
+        [
+            pytest.param(np.array([1.0, 2.0]), id="numpy-array"),
+            pytest.param(np.float32(1.0), id="numpy-float32-is-not-a-float-subclass"),
+            pytest.param(1, id="python-int"),
+            pytest.param("1.0", id="string"),
+        ],
+    )
+    def test_params_non_float_leaf_raises_typeerror(self, leaf):
+        """params leaves that are neither jax.Arrays nor floats should be rejected."""
+
+        def nll(params, observation):
+            return params["x"] ** 2
+
+        with pytest.raises(TypeError, match=r"params\['x'\]"):
+            ew.fit(nll, sl.State.from_pytree({"x": leaf}), {})
+
+    def test_fixed_python_scalar_converted_to_jax_array(self):
+        """Python-scalar fixed values are converted once at the fit() boundary."""
+
+        def nll(params, observation):
+            return (params["x"] - 2.0) ** 2 + (params["y"] - 3.0) ** 2
+
+        params = sl.State.from_pytree({"x": 0.0, "y": 0.0})
+
+        result = ew.fit(nll, params, {}, fixed=sl.State.from_pytree({"y": 1.5}))
+
+        assert isinstance(result.params["y"], jax.Array)
+        assert result.params["y"] == 1.5
+
+    def test_fixed_non_scalar_leaf_raises_typeerror(self):
+        """fixed leaves that are neither jax.Arrays, scalars, nor Ellipsis should be rejected."""
+
+        def nll(params, observation):
+            return params["x"] ** 2 + params["y"] ** 2
+
+        params = sl.State.from_pytree({"x": 0.0, "y": 0.0})
+
+        with pytest.raises(TypeError, match=r"fixed\['y'\]"):
+            ew.fit(nll, params, {}, fixed=sl.State.from_pytree({"y": np.array([1.0])}))
+
+    def test_fixed_ellipsis_sentinel_fixes_at_initial_value(self):
+        """Ellipsis in fixed passes validation and fixes the parameter at its initial value."""
+
+        def nll(params, observation):
+            return (params["x"] - 2.0) ** 2 + (params["y"] - 3.0) ** 2
+
+        params = sl.State.from_pytree({"x": 0.0, "y": 0.5})
+
+        result = ew.fit(nll, params, {}, fixed=sl.State.from_pytree({"y": ...}))
+
+        assert jnp.isclose(result.params["x"], 2.0, atol=1e-2)
+        assert result.params["y"] == 0.5
+
+    def test_ifit_params_non_scalar_leaf_raises_typeerror(self):
+        """ifit shares the leaf validation with fit."""
+
+        def nll(params, observation):
+            return params["x"] ** 2
+
+        with pytest.raises(TypeError, match=r"params\['x'\]"):
+            ew.ifit(nll, sl.State.from_pytree({"x": np.array([1.0])}), {}, progress=False)
+
+
+# ============================================================================
+# JIT retrace regression tests
+# ============================================================================
+
+
+class TestFitRetrace:
+    """Repeated fit() calls must reuse already-compiled code."""
+
+    def test_repeated_fit_with_different_fixed_values_does_not_retrace(self):
+        """Changing a fixed parameter's float value between fits must not retrigger tracing."""
+        trace_count = [0]
+
+        def nll(params, observation):
+            if isinstance(params["x"], jax.core.Tracer):
+                trace_count[0] += 1
+            return (params["x"] - observation["target"]) ** 2 + (params["y"] - 1.0) ** 2
+
+        params = sl.State.from_pytree({"x": 0.0, "y": 0.0})
+        observation = {"target": 2.0}
+
+        ew.fit(nll, params, observation, fixed=sl.State.from_pytree({"y": 0.5}))
+        traces_after_first = trace_count[0]
+
+        result = ew.fit(nll, params, observation, fixed=sl.State.from_pytree({"y": 1.5}))
+
+        assert trace_count[0] == traces_after_first
+        assert result.params["y"] == 1.5
+        assert jnp.isclose(result.params["x"], 2.0, atol=1e-2)
 
 
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -686,12 +686,16 @@ wheels = [
 [[package]]
 name = "evermore"
 version = "0.4.1"
-source = { git = "https://github.com/pfackeldey/evermore?rev=v0.4.1#b78d7658557c853c474b6dc286c60b249fe87878" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flax" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/40/9aead8ce4e8837a9e781ac3e57538bca9c613c4f5e278c5c83a9ca5462fb/evermore-0.4.1.tar.gz", hash = "sha256:a7a3f37a67bc27468f336ffba043e3264afac3d2772557e037838a978cdc8813", size = 150970, upload-time = "2026-01-08T11:35:36.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/13/5b3c0e1610beb3aa395261d737211cb4d8993999b19e45b6adbce5c1d2d7/evermore-0.4.1-py3-none-any.whl", hash = "sha256:c906ccac7d73de175ef875e086ceab56d430f34c22e861a4165c091ebad99ec4", size = 25302, upload-time = "2026-01-08T11:35:35.293Z" },
 ]
 
 [[package]]
@@ -802,7 +806,7 @@ examples = [
     { name = "evermore", specifier = ">=0.4.1" },
     { name = "iminuit", specifier = ">=2.32.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
-    { name = "paramore", git = "https://github.com/maxgalli/paramore?branch=master" },
+    { name = "paramore", git = "https://github.com/maxgalli/paramore?branch=feat%2Fbernstein-analytical-integrate" },
     { name = "pyhf", git = "https://github.com/scikit-hep/pyhf?branch=main" },
     { name = "pyhs3", git = "https://github.com/MoAly98/pyhs3?branch=fix%2Ffuncs_ref_funcs" },
     { name = "rich" },
@@ -2314,11 +2318,12 @@ wheels = [
 [[package]]
 name = "paramore"
 version = "0.1.0"
-source = { git = "https://github.com/maxgalli/paramore?branch=master#e54c64107bddc6d1ed374924f36b216cec93bd01" }
+source = { git = "https://github.com/maxgalli/paramore?branch=feat%2Fbernstein-analytical-integrate#88dfeec0ad7427cc1e62f32ec10f40ed4fdee160" }
 dependencies = [
     { name = "dask" },
     { name = "distributed" },
     { name = "evermore" },
+    { name = "everwillow" },
     { name = "iminuit" },
     { name = "ipython" },
     { name = "jax" },
@@ -2371,7 +2376,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
- Replace per-call NLL closure with reusable `_WrappedNLL` eqx.Module to avoid JIT retracing
- Convert `fixed_state` leaves to JAX arrays so POI test values are treated as dynamic inputs
- Fix `_WrappedNLL` docstring to accurately reflect that observation is stored as-is (not coerced to JAX arrays)
- Update `paramore` source to `feat/bernstein-analytical-integrate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fitting behavior to accept plain numeric inputs more consistently and reject unsupported values earlier.
  * Fixed handling of repeated fit calls so changing fixed numeric values no longer causes unnecessary retracing.
  * Made asymptotic hypothesis-test calculations more robust when expected intermediate results are unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->