### PR TITLE
feat: expose uncertainties at top-level everwillow namespace

### DIFF
--- a/src/everwillow/__init__.py
+++ b/src/everwillow/__init__.py
@@ -8,10 +8,12 @@ __version__ = "0.1.2"
 
 # Core API
 from everwillow._src.inference.fitting import FitResult, fit, ifit, prepare
+from everwillow._src.inference.uncertainty import uncertainties
 
 __all__ = [
     "FitResult",
     "fit",
     "ifit",
     "prepare",
+    "uncertainties",
 ]


### PR DESCRIPTION
Lifts `uncertainties` from `everwillow.uncertainty` to the top-level `everwillow` namespace so callers can write `ew.uncertainties(...)` alongside `ew.fit(...)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `uncertainties` is now available as part of the public API and can be imported directly from the main package alongside other core functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MoAly98/everwillow/pull/61)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->